### PR TITLE
feat: add SetLinkPreference API msg compose

### DIFF
--- a/src/amt/actions.ts
+++ b/src/amt/actions.ts
@@ -35,7 +35,8 @@ export enum Actions {
   GET_ADMIN_ACL_ENTRY_STATUS = 'http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminAclEntryStatus',
   GET_ADMIN_NET_ACL_ENTRY_STATUS = 'http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAdminNetAclEntryStatus',
   SET_ACL_ENABLED_STATE = 'http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/SetAclEnabledState',
-  GET_ACL_ENABLED_STATE = 'http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAclEnabledState'
+  GET_ACL_ENABLED_STATE = 'http://intel.com/wbem/wscim/1/amt-schema/1/AMT_AuthorizationService/GetAclEnabledState',
+  SET_LINK_PREFERENCE = 'http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings/SetLinkPreference'
 }
 
 export enum Realms {

--- a/src/amt/messages.test.ts
+++ b/src/amt/messages.test.ts
@@ -414,6 +414,26 @@ describe('AMT Tests', () => {
       const response = amtClass.EthernetPortSettings.Put(testBody)
       expect(response).toEqual(correctResponse)
     })
+    it('should create a valid amt_EthernetPortSettings SetLinkPreference wsman message with default instanceID', () => {
+      const correctResponse = `${xmlHeader}${envelope}http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings/SetLinkPreference</a:Action><a:To>/wsman</a:To><w:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings</w:ResourceURI><a:MessageID>${(messageId++).toString()}</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><w:OperationTimeout>${operationTimeout}</w:OperationTimeout><w:SelectorSet><w:Selector Name="InstanceID">Intel(r) AMT Ethernet Port Settings 1</w:Selector></w:SelectorSet></Header><Body><h:SetLinkPreference_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings"><h:LinkPreference>1</h:LinkPreference><h:Timeout>300</h:Timeout></h:SetLinkPreference_INPUT></Body></Envelope>`
+      const response = amtClass.EthernetPortSettings.SetLinkPreference(1, 300)
+      expect(response).toEqual(correctResponse)
+    })
+    it('should create a valid amt_EthernetPortSettings SetLinkPreference wsman message with custom instanceID', () => {
+      const correctResponse = `${xmlHeader}${envelope}http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings/SetLinkPreference</a:Action><a:To>/wsman</a:To><w:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings</w:ResourceURI><a:MessageID>${(messageId++).toString()}</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><w:OperationTimeout>${operationTimeout}</w:OperationTimeout><w:SelectorSet><w:Selector Name="InstanceID">Intel(r) AMT Ethernet Port Settings 1</w:Selector></w:SelectorSet></Header><Body><h:SetLinkPreference_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings"><h:LinkPreference>2</h:LinkPreference><h:Timeout>600</h:Timeout></h:SetLinkPreference_INPUT></Body></Envelope>`
+      const response = amtClass.EthernetPortSettings.SetLinkPreference(2, 600, 'Intel(r) AMT Ethernet Port Settings 1')
+      expect(response).toEqual(correctResponse)
+    })
+    it('should create a valid amt_EthernetPortSettings SetLinkPreference wsman message with linkPreference=1 (ME)', () => {
+      const correctResponse = `${xmlHeader}${envelope}http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings/SetLinkPreference</a:Action><a:To>/wsman</a:To><w:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings</w:ResourceURI><a:MessageID>${(messageId++).toString()}</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><w:OperationTimeout>${operationTimeout}</w:OperationTimeout><w:SelectorSet><w:Selector Name="InstanceID">Intel(r) AMT Ethernet Port Settings 1</w:Selector></w:SelectorSet></Header><Body><h:SetLinkPreference_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings"><h:LinkPreference>1</h:LinkPreference><h:Timeout>600</h:Timeout></h:SetLinkPreference_INPUT></Body></Envelope>`
+      const response = amtClass.EthernetPortSettings.SetLinkPreference(1, 600)
+      expect(response).toEqual(correctResponse)
+    })
+    it('should create a valid amt_EthernetPortSettings SetLinkPreference wsman message with linkPreference=2 (HOST)', () => {
+      const correctResponse = `${xmlHeader}${envelope}http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings/SetLinkPreference</a:Action><a:To>/wsman</a:To><w:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings</w:ResourceURI><a:MessageID>${(messageId++).toString()}</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><w:OperationTimeout>${operationTimeout}</w:OperationTimeout><w:SelectorSet><w:Selector Name="InstanceID">Intel(r) AMT Ethernet Port Settings 1</w:Selector></w:SelectorSet></Header><Body><h:SetLinkPreference_INPUT xmlns:h="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_EthernetPortSettings"><h:LinkPreference>2</h:LinkPreference><h:Timeout>120</h:Timeout></h:SetLinkPreference_INPUT></Body></Envelope>`
+      const response = amtClass.EthernetPortSettings.SetLinkPreference(2, 120)
+      expect(response).toEqual(correctResponse)
+    })
   })
   describe('GeneralSettings Tests', () => {
     it('should return a valid amt_GeneralSettings Get wsman message', () => {

--- a/src/amt/messages.ts
+++ b/src/amt/messages.ts
@@ -271,6 +271,27 @@ class EthernetPortSettings extends Base {
    * @returns string
    */
   Put = (ethernetPortObject: Models.EthernetPortSettings): string => this.protectedPut(ethernetPortObject, true)
+
+  /**
+   * Sets link preference with timeout.
+   * @param linkPreference 1 = ME | 2 = HOST
+   * @param timeout Timeout in seconds before preference expires.
+   * @param instanceID The InstanceID selector for the specific Ethernet port (e.g., "Intel(r) AMT Ethernet Port Settings 1")
+   * @returns string
+   */
+  SetLinkPreference = (
+    linkPreference: Types.EthernetPortSettings.LinkPreference,
+    timeout: number,
+    instanceID = 'Intel(r) AMT Ethernet Port Settings 1'
+  ): string => {
+    const selector = { name: 'InstanceID', value: instanceID }
+    const header = this.wsmanMessageCreator.createHeader(Actions.SET_LINK_PREFERENCE, this.className, selector)
+    const body = this.wsmanMessageCreator.createBody('SetLinkPreference_INPUT', this.className, [
+      { LinkPreference: linkPreference },
+      { Timeout: timeout }
+    ])
+    return this.wsmanMessageCreator.createXml(header, body)
+  }
 }
 class GeneralSettings extends Base {
   className = Classes.GENERAL_SETTINGS


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?
- add SetLinkPreference API for composing wsman message
  - instanceID in header
  - linkPreference, and timeout in body

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?
- This PR is to handle issue:
  - https://github.com/device-management-toolkit/mps/issues/1941

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
- This wsman-messages PR is being used by this MPS PR: 
  - https://github.com/device-management-toolkit/mps/pull/2202

