### PR TITLE
chore: update build tasks & package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write # for Git to git push
+      contents: write # @semantic-release/git pushes changelog + version bump to main
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@device-management-toolkit/wsman-messages",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@device-management-toolkit/wsman-messages",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@device-management-toolkit/wsman-messages",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "A reusable package for AMT libraries",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Clarify via inline comment that the release job's contents:write is required by @semantic-release/git, which pushes the changelog and version bump to main. Comment-only change to release.yml; cuts a patch release so the accumulated build(deps) updates get published and package.json is bumped.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
