### PR TITLE
ci: Enable Semgrep and Zizmor scans

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: Semgrep Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+jobs:
+  semgrep:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep@sha256:14e073f6417e5d2d0797aa13f26d569270b86fac9d52052d2358c985f1a4e9f0  # v1.124.0
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run Semgrep scan
+        uses: open-edge-platform/orch-ci/.github/actions/security/semgrep@8e869384de7ed5f98941c59c2e4ac73eb09862fb  # 2026.1.3
+        with:
+          scan-scope: all
+          severity: "HIGH"
+          output-format: "text"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: Zizmor Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    permissions:
+      contents: read
+      security-events: write
+
+    runs-on: ubuntu-latest
+
+    env:
+      ZIZMOR_VERSION: 1.20.0
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Run Zizmor
+        run: |
+          uvx zizmor=="$ZIZMOR_VERSION" \
+            --format sarif \
+            .github \
+            > zizmor_scan_report.sarif
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: zizmor_scan_report.sarif
+
+      - name: Upload Zizmor report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zizmor-results
+          path: zizmor_scan_report.sarif
+          retention-days: 7


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate security scanning for the repository. The workflows integrate Semgrep and Zizmor scanning tools, ensuring code is checked for security issues on every push and pull request to the `main` branch. Both workflows include steps to harden the runner, check out code, run the respective scans, and handle the results.

Jira: https://jira.devtools.intel.com/browse/NEXUIE-132281 

**Security scanning workflows:**

* **Semgrep scan workflow:**
  - Introduces `.github/workflows/semgrep.yml` to run Semgrep scans on code changes, configured to focus on high-severity issues and output results in text format.

* **Zizmor scan workflow:**
  - Adds `.github/workflows/zizmor.yml` to perform Zizmor scans, generate SARIF reports, and upload them to GitHub Security and as workflow artifacts.

**Security and runner hardening:**

* Both workflows use the `step-security/harden-runner` action to audit egress traffic and improve security posture during workflow execution. [[1]](diffhunk://#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbbR1-R38) [[2]](diffhunk://#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7R1-R61)

**Code checkout and dependency setup:**

* Both workflows utilize `actions/checkout` for code retrieval, and the Zizmor workflow installs the `uv` dependency manager for running Zizmor. [[1]](diffhunk://#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbbR1-R38) [[2]](diffhunk://#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7R1-R61)
